### PR TITLE
Do not return pointer to local variable.

### DIFF
--- a/Common/sources/InfosvrExploit.cpp
+++ b/Common/sources/InfosvrExploit.cpp
@@ -83,7 +83,8 @@ char* getResponse(IBOX_COMM_PKT_HDR_EX* phdr_ex, SOCKET sock, SOCKADDR_IN* targe
 	IBOX_COMM_PKT_RES_EX *phdr_res	= (IBOX_COMM_PKT_RES_EX*)pdubuf_res;							// receive buffer header
 	PKT_SYSCMD_RES *syscmd_res		= (PKT_SYSCMD_RES*)(pdubuf_res+sizeof(IBOX_COMM_PKT_RES_EX));	// receive buffer body
 
-	char resBuf[SYSCMDBUF_RES_MAX+1] = "";	// response text
+	static char resBuf[SYSCMDBUF_RES_MAX+1];	// response text
+    resBuf[0] = '\0';
 	BOOL resGot = FALSE;
 
 	for (int i = 0; i < RECV_MAX; i++)


### PR DESCRIPTION
Since the app is single-threaded and the result is always utilized before method is called, the simplest fix is to declare the variable static.
